### PR TITLE
Fixing getFileName not supporting dots in path

### DIFF
--- a/lib/canvas/canvas.ts
+++ b/lib/canvas/canvas.ts
@@ -294,7 +294,9 @@ const getFileName = (
     return path;
   }
   const limit = 50;
-  const [name, extention] = path.split('.');
+  const idx = path.lastIndexOf('.');
+  const name = path.substring(0, idx);
+  const extention = path.substring(idx);
   for (let i = 0; i < limit; i++) {
     const newPath = `${name}-${i}.${extention}`;
     log.info(newPath);

--- a/lib/canvas/canvas.ts
+++ b/lib/canvas/canvas.ts
@@ -296,7 +296,7 @@ const getFileName = (
   const limit = 50;
   const idx = path.lastIndexOf('.');
   const name = path.substring(0, idx);
-  const extention = path.substring(idx);
+  const extention = path.substring(idx + 1);
   for (let i = 0; i < limit; i++) {
     const newPath = `${name}-${i}.${extention}`;
     log.info(newPath);


### PR DESCRIPTION
Previous Bug: ``getFileName`` split up a path ``/path/with.dots/file.md`` into ``["/path/with", "dots/file.md"]``, as it was only checking for the first dot in path.

Now the path is split at the last index (``"/path/with.dots/file", ".md"]``, as it's supposed to be.

